### PR TITLE
Use sudo to restart service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
           username: ${{ secrets.REMOTE_USER }}
           password: ${{ secrets.REMOTE_PASSWD }}
           port: ${{ secrets.REMOTE_PORT }}
-          script: systemctl restart otherdave
+          script: sudo systemctl restart otherdave


### PR DESCRIPTION
REMOTE_USER now has sudo permissions _only_ to restart its own specific service in order to unblock the ssh step of deployment.