### PR TITLE
Handle replacements of role tags and users with nicknames

### DIFF
--- a/otherdave/commands/mimic.py
+++ b/otherdave/commands/mimic.py
@@ -16,7 +16,7 @@ def listen(message):
         return
 
     user = message.author.id
-    if("<@&" in content):
+    if("<@&" in message.content):
         content = re.sub("<@&\d+>", "<@&ROLE>", message.content)
     content = re.sub("<@!*\d+>", "<@USER>", message.content)
     if(not content.endswith(".")):

--- a/otherdave/commands/mimic.py
+++ b/otherdave/commands/mimic.py
@@ -16,7 +16,9 @@ def listen(message):
         return
 
     user = message.author.id
-    content = re.sub("<@\d+>", "<@USER>", message.content)
+    if("<@&" in content):
+        content = re.sub("<@&\d+>", "<@&ROLE>", message.content)
+    content = re.sub("<@!*\d+>", "<@USER>", message.content)
     if(not content.endswith(".")):
         # Markovify doesn't treat \n as punctuation...
         content = content + "."

--- a/otherdave/commands/mimic.py
+++ b/otherdave/commands/mimic.py
@@ -16,9 +16,11 @@ def listen(message):
         return
 
     user = message.author.id
-    if("<@&" in message.content):
-        content = re.sub("<@&\d+>", "<@&ROLE>", message.content)
-    content = re.sub("<@!*\d+>", "<@USER>", message.content)
+    content = message.content
+    
+    if("<@&" in content):
+        content = re.sub("<@&\d+>", "<@&ROLE>", content)
+    content = re.sub("<@!*\d+>", "<@USER>", content)
     if(not content.endswith(".")):
         # Markovify doesn't treat \n as punctuation...
         content = content + "."


### PR DESCRIPTION
> How Discord mentions work
Discord uses a special syntax to embed mentions in a message. For user mentions, it is the user's ID with <@ at the start and > at the end, like this: <@86890631690977280>. If they have a nickname, there will also be a ! after the @.

Discord also uses <@& ... > to embed roles.