### PR TITLE
Fix exception in find, don't crash background thread on error

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,5 +1,5 @@
 # https://semver.org/
-version: '2.3.11, now proudly on python :snake:'
+version: '2.3.12, now proudly on python :snake:'
 description: |+ 
   OtherDave is not David.
   

--- a/otherdave/__main__.py
+++ b/otherdave/__main__.py
@@ -32,7 +32,11 @@ logger.addHandler(handler)
 # Configure tasks
 @tasks.loop(seconds=int(config["parrot_interval"]))
 async def squawk():
-    await toucan(client, lastMsgTime, quietTime)
+    try:
+        await toucan(client, lastMsgTime, quietTime)
+    except Exception as error:
+        dlog(client, str(error))
+        pass
 
 # Configure commands
 @client.command(

--- a/otherdave/commands/give.py
+++ b/otherdave/commands/give.py
@@ -104,7 +104,7 @@ def find():
     if (bag.llen(inventoryKey) > bagsize):
         oldThing = bag.lpop(inventoryKey, 0)
         newThings.pop(oldThing, None)
-        return _foundfulMessage.format(oldThing = oldThing, newThing = thing)
+        return _foundfulMessage.format(oldThing = oldThing, thing = thing)
     else:
         return _foundMessage.format(thing = thing)
 


### PR DESCRIPTION
Seems like if a background process hits an exception, the process isn't restarted. 
Fix the issue that caused the exception in the first place, and wrap the looped task in a try/except.