### PR TITLE
Fix bug in madlibber related to leading chars

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,5 +1,5 @@
 # https://semver.org/
-version: '2.3.13, now proudly on python :snake:'
+version: '2.3.14, now proudly on python :snake:'
 description: |+ 
   OtherDave is not David.
   

--- a/otherdave/util/madlib.py
+++ b/otherdave/util/madlib.py
@@ -13,10 +13,10 @@ class MadLibber():
         tokens = template.split(" ")
         result = ""
         for token in tokens:
-            action = re.match("\{\{(.+?)\}\}(.*)", token)
+            action = re.match("(.*)\{\{(.+?)\}\}(.*)", token)
             if(action):
-                if(action[1] in self.actions):
-                    result += self.actions[action[1]]() + action[2]
+                if(action[2] in self.actions):
+                    result += action[1] + self.actions[action[2]]() + action[3]
                 else:
                     result += action[0]
             else:


### PR DESCRIPTION
{{action}}'s was fine because I added a capture group for trailing chars but I didn't think to add a capture group for leading chars too. Fixing that here so that item types actually work.