### PR TITLE
Fix bug in how item types are parsed in use( )

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,5 +1,5 @@
 # https://semver.org/
-version: '2.3.14, now proudly on python :snake:'
+version: '2.3.15, now proudly on python :snake:'
 description: |+ 
   OtherDave is not David.
   

--- a/otherdave/commands/give.py
+++ b/otherdave/commands/give.py
@@ -221,14 +221,14 @@ def use(mention = selftag, thing = "something", who= "I", whos = "I'm", whose = 
 
     bag.lremvalue(mention, typedThing)
     
-    unflectedthing = thing.split(")")
+    unflectedthing = typedThing.split(")")
     unflectedthing = unflectedthing[0] + ")" + unflect_a(unflectedthing[1])
 
     return user.make().format(
         who = who, 
         whose = whose, 
         thing = unflectedthing, 
-        a_thing = thing)
+        a_thing = typedThing)
 
 def useCmd(author, *args):
     if (len(args) < 2 and args[0] == "-my"):


### PR DESCRIPTION
Was incorrectly parsing out the un-typed object from the command args, rather than the typed object from the inventory.