### PR TITLE
Fix how found items are inflected

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,5 +1,5 @@
 # https://semver.org/
-version: '2.3.15, now proudly on python :snake:'
+version: '2.3.16, now proudly on python :snake:'
 description: |+ 
   OtherDave is not David.
   

--- a/otherdave/commands/give.py
+++ b/otherdave/commands/give.py
@@ -93,7 +93,8 @@ def unflect_a(word: str) -> str:
 def unflect_an(word: str) -> str: return unflect_a(word)
 
 def find():
-    thing = infl.a(thinger.make())
+    thing = thinger.make().split(")")
+    thing = thing[0] + ")" + infl.a(thing[1])
 
     # Put the new thing in the bag
     bag.ladd(inventoryKey, thing)


### PR DESCRIPTION
Failed to update find with the new split and re-join inflect pattern, so the indefinite article is being slapped in front of the type and screwing up inventory access.