### PR TITLE
Fix issue in automatic item drop

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,5 +1,5 @@
 # https://semver.org/
-version: '2.3.18, now proudly on python :snake:'
+version: '2.3.19, now proudly on python :snake:'
 description: |+ 
   OtherDave is not David.
   

--- a/otherdave/commands/give.py
+++ b/otherdave/commands/give.py
@@ -196,7 +196,14 @@ def drop(mention, thing):
     if (not bag.exists(mention)):
         return _noDropMessage.format(who = who, thing = thing)
 
-    typedThing = bag.lgetrg(mention, "^(\(:[a-z_]+:\) )*" + thing + "$")
+    if (not "(:" in thing
+        or not ":)" in thing):
+        typedThing = bag.lgetrg(mention, "^(\(:[a-z_]+:\) )*" + thing + "$")
+    elif (bag.lexists(mention, thing)):
+        typedThing = typedThing
+    else:
+        typedThing = None
+
     if (typedThing == None):
         return _noDropMessage.format(who = who, thing = thing)
 

--- a/otherdave/commands/give.py
+++ b/otherdave/commands/give.py
@@ -214,7 +214,7 @@ def selfdrop():
     thing = random.choice(bag.lgetall(inventoryKey))
     return drop(inventoryKey, thing)
 
-def use(mention = selftag, thing = "something", who= "I", whos = "I'm", whose = "my"):
+def use(mention = inventoryKey, thing = "something", who= "I", whos = "I'm", whose = "my"):
     if (thing == "something"):
         if (not bag.exists(mention)
             or bag.llen(mention) == 0):


### PR DESCRIPTION
Auto-drop calls were trying to drop already-typed items, but drop( ) wasn't handling typed things correctly. Updating the call to support both typed and untyped things so he stops spamming "But I'm not carrying anything!" all the time.